### PR TITLE
expose desk power to google assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Added
 
+- Button for desk power to office view.
 - Cameras from Frigate streams.
 - This changelog.
 
 ### Changed
 
+- Exposed desk power switch to Google Assistant.
 - Use the Frigate in Lovelace instead of direct streams from the cameras.

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -107,6 +107,11 @@ google_assistant:
     # tradfri pc power outlet
     switch.0x086bd7fffe19c5dd_switch:
       name: PC power
+    # tradfri desk power outlet
+    switch.0x000d6ffffe2a5801:
+      name: desk
+      aliases: desk power
+      room: office
     # night mode toggle
     input_boolean.night_mode_toggle:
       name: night mode

--- a/lovelace/00_home.yaml
+++ b/lovelace/00_home.yaml
@@ -211,9 +211,10 @@ cards:
   title: Kitchen
 - type: picture-glance
   entities:
-    - light.office_uplighter
     - light.office_lamp
-    - switch.desk_power_2
+    - light.office_standard_lamp
+    - light.office_ceiling_lamp
+    - switch.0x000d6ffffe2a5801
   hold_action:
     action: navigate
     navigation_path: /lovelace/office/

--- a/lovelace/20_office.yaml
+++ b/lovelace/20_office.yaml
@@ -46,6 +46,22 @@ cards:
             type: entity-button
             double_tap_action:
               action: none
+            entity: switch.0x000d6ffffe2a5801
+            hold_action:
+              action: none
+            icon: "mdi:power"
+            name_template: '{{ "Turn desk off" if is_state("switch.0x000d6ffffe2a5801", "on") else "Turn desk power on" }}'
+            show_icon: false
+            show_state: false
+            tap_action:
+              action: toggle
+          entities:
+            - switch.0x000d6ffffe2a5801
+        - type: "custom:card-templater"
+          card:
+            type: entity-button
+            double_tap_action:
+              action: none
             entity: switch.0x086bd7fffe19c5dd_switch
             hold_action:
               action: none


### PR DESCRIPTION
- added button for desk power to office view.
- Exposed desk power switch to Google Assistant.
- tidied picture entities on main dashboard view.